### PR TITLE
Mark the expression to avoid reprocessing the same expression.

### DIFF
--- a/fixtures/assert-expansion/expectation.js
+++ b/fixtures/assert-expansion/expectation.js
@@ -1,2 +1,2 @@
-(true && !((() => true)()) && console.assert((() => true)(), 'This is an assertion'));
+(true && !((() => true)()) && console.assert(false, 'This is an assertion'));
 (true && !(false) && console.assert(false, 'This is an assertion 2'));

--- a/fixtures/ember-cli-babel-config/expectation.js
+++ b/fixtures/ember-cli-babel-config/expectation.js
@@ -5,9 +5,9 @@ if (true) {
 }
 
 (true && Ember.warn('This is a warning'));
-(true && !(foo) && Ember.assert('Hahahaha', foo));
-(true && !(false) && Ember.assert('without predicate'));
-(true && !(true) && Ember.deprecate('This thing is donzo', true, {
+(true && !(foo) && Ember.assert('Hahahaha', false));
+(true && !(false) && Ember.assert('without predicate', false));
+(true && !(true) && Ember.deprecate('This thing is donzo', false, {
   id: 'donzo',
   until: '4.0.0',
   url: 'http://example.com'

--- a/fixtures/global-external-helpers/expectation.js
+++ b/fixtures/global-external-helpers/expectation.js
@@ -1,6 +1,6 @@
 (true && __debugHelpers__.warn('This is a warning'));
 (true && __debugHelpers__.assert('Hahahaha', foo));
-(true && !(true) && __debugHelpers__.deprecate('This thing is donzo', true, {
+(true && !(true) && __debugHelpers__.deprecate('This thing is donzo', false, {
   id: 'donzo',
   until: '4.0.0',
   url: 'http://example.com'

--- a/fixtures/retain-module-external-helpers/expectation.js
+++ b/fixtures/retain-module-external-helpers/expectation.js
@@ -2,7 +2,7 @@ import { warn, assert, deprecate } from '@ember/debug-tools';
 
 (true && warn('This is a warning'));
 (true && assert('Hahahaha', false));
-(true && !(true) && deprecate('This thing is donzo', true, {
+(true && !(true) && deprecate('This thing is donzo', false, {
   id: 'donzo',
   until: '4.0.0',
   url: 'http://example.com'

--- a/src/lib/utils/macros.js
+++ b/src/lib/utils/macros.js
@@ -138,9 +138,14 @@ export default class Macros {
   build(path) {
     let expression = path.node.expression;
     let { builder, localDebugBindings } = this;
-    if (builder.t.isCallExpression(expression) && localDebugBindings.some((b) => b.node.name === expression.callee.name)) {
+    if (
+      builder.t.isCallExpression(expression) &&
+        localDebugBindings.some((b) => b.node.name === expression.callee.name) &&
+      expression._debugMacrosProcessed !== true
+    ) {
       let imported = path.scope.getBinding(expression.callee.name).path.node.imported.name;
       this.builder[`${imported}`](path);
+      expression._debugMacrosProcessed = true;
     }
   }
 


### PR DESCRIPTION
In some circumstances, Babel will re-traverse the same path. This is generally caused by other plugins needing to process the path also (which our tests do not currently exercise) which then causes a second traversal (to ensure the our plugin has access to the changed expression).

When this re-traversal happens, we end up pushing another entry into `Builder#expressions` with the same `path` which _roughly_ equates to the "last one wins".  Prior to recent changes to avoid duplicating the statements predicate this was fine, but after that change we now mutate the `expressions.arguments` to replace the predicate with `false`. This means that the second traversal path takes that `false` literal and uses it as the predicate itself (causing the "real" predicate to be completely lost).

This change marks a given expression as "seen" so that we do not reprocess an already processed expression.

---

The primary changes being discussed here are in the [second commit](https://github.com/chadhietala/babel-plugin-debug-macros/pull/41/commits/6b75490ee959c2240aef5102d032e0724453dbf8).