### PR TITLE
Fix bug when key attribute is a literal

### DIFF
--- a/src/utils/builder.js
+++ b/src/utils/builder.js
@@ -157,11 +157,11 @@ module.exports = class Builder {
       validate: (expression, args) => {
         let meta = args[2];
 
-        if (meta && meta.properties && !meta.properties.some(prop => prop.key.name === 'id')) {
+        if (meta && meta.properties && !meta.properties.some(prop => prop.key.name === 'id' || prop.key.value === 'id')) {
           throw new ReferenceError(`deprecate's meta information requires an "id" field.`);
         }
 
-        if (meta && meta.properties && !meta.properties.some(prop => prop.key.name === 'until')) {
+        if (meta && meta.properties && !meta.properties.some(prop => prop.key.name === 'until' || prop.key.value === 'until')) {
           throw new ReferenceError(`deprecate's meta information requires an "until" field.`);
         }
       },


### PR DESCRIPTION
"key" attribute can be a Literal (https://babeljs.io/docs/en/babel-types#objectproperty) in which case `validate` needs to look for a `value` prop instead of `name`

I was getting the `deprecate's meta information requires an "id" field.` error when trying to build a new Ember app with embroider and ember-table. Turned out that in one nested dependency of ember-table `ember-cli-page-object`, the deprecate method (https://github.com/san650/ember-cli-page-object/blob/master/addon-test-support/-private/helpers.js#L39) was causing the error. Looking at the `meta` object, the `id` and `until` fields are present but under a `value` prop instead of `name`.