### PR TITLE
Remove validation check for deprecation `until`

### DIFF
--- a/src/utils/builder.js
+++ b/src/utils/builder.js
@@ -164,14 +164,6 @@ module.exports = class Builder {
         ) {
           throw new ReferenceError(`deprecate's meta information requires an "id" field.`);
         }
-
-        if (
-          meta &&
-          meta.properties &&
-          !meta.properties.some(prop => prop.key.name === 'until' || prop.key.value === 'until')
-        ) {
-          throw new ReferenceError(`deprecate's meta information requires an "until" field.`);
-        }
       },
     });
   }


### PR DESCRIPTION
This transform currently verifies that `deprecate()` has a meta object
with `id` and `until`. This info is helpful, but there are potential
cases where the `until` may not be known, but we still want this
stripping functionality.

For instance, we're planning on adding `deprecate` to Glimmer VM. We
still want the VM to be able to strip out these `deprecate` calls, but
the VM ultimately isn't responsible for determining the major versions
when the feature will be removed - that's up to the host environment.
The plan is to have the host environment add `until` dynamically.

I believe `id` is the only bit of metadata that is universal, so I
decided to keep it.d