### PR TITLE
Add tests for Ember 3.27+ modules based API.

### DIFF
--- a/fixtures/ember-cli-babel-config-pre-3-27/expectation6.js
+++ b/fixtures/ember-cli-babel-config-pre-3-27/expectation6.js
@@ -1,0 +1,14 @@
+
+
+if (true /* DEBUG */) {
+  doStuff();
+}
+
+(true && Ember.warn('This is a warning'));
+(true && !(foo) && Ember.assert('Hahahaha', foo));
+(true && !(false) && Ember.assert('without predicate'));
+(true && !(true) && Ember.deprecate('This thing is donzo', true, {
+  id: 'donzo',
+  until: '4.0.0',
+  url: 'http://example.com'
+}));

--- a/fixtures/ember-cli-babel-config-pre-3-27/expectation7.js
+++ b/fixtures/ember-cli-babel-config-pre-3-27/expectation7.js
@@ -1,0 +1,14 @@
+if (true
+/* DEBUG */
+) {
+  doStuff();
+}
+
+(true && Ember.warn('This is a warning'));
+(true && !(foo) && Ember.assert('Hahahaha', foo));
+(true && !(false) && Ember.assert('without predicate'));
+(true && !(true) && Ember.deprecate('This thing is donzo', true, {
+  id: 'donzo',
+  until: '4.0.0',
+  url: 'http://example.com'
+}));

--- a/fixtures/ember-cli-babel-config-pre-3-27/sample.js
+++ b/fixtures/ember-cli-babel-config-pre-3-27/sample.js
@@ -1,0 +1,17 @@
+import { warn, assert, deprecate } from '@ember/debug';
+import { DEBUG } from '@glimmer/env';
+
+if (DEBUG) {
+  doStuff();
+}
+
+warn('This is a warning');
+
+assert('Hahahaha', foo);
+assert('without predicate');
+
+deprecate('This thing is donzo', true, {
+  id: 'donzo',
+  until: '4.0.0',
+  url: 'http://example.com'
+});

--- a/fixtures/ember-cli-babel-config/expectation6.js
+++ b/fixtures/ember-cli-babel-config/expectation6.js
@@ -1,13 +1,14 @@
+import { warn, assert, deprecate } from '@ember/debug';
 
 
 if (true /* DEBUG */) {
   doStuff();
 }
 
-(true && Ember.warn('This is a warning'));
-(true && !(foo) && Ember.assert('Hahahaha', foo));
-(true && !(false) && Ember.assert('without predicate'));
-(true && !(true) && Ember.deprecate('This thing is donzo', true, {
+(true && warn('This is a warning'));
+(true && !(foo) && assert('Hahahaha', foo));
+(true && !(false) && assert('without predicate'));
+(true && !(true) && deprecate('This thing is donzo', true, {
   id: 'donzo',
   until: '4.0.0',
   url: 'http://example.com'

--- a/fixtures/ember-cli-babel-config/expectation7.js
+++ b/fixtures/ember-cli-babel-config/expectation7.js
@@ -1,13 +1,15 @@
+import { warn, assert, deprecate } from '@ember/debug';
+
 if (true
 /* DEBUG */
 ) {
   doStuff();
 }
 
-(true && Ember.warn('This is a warning'));
-(true && !(foo) && Ember.assert('Hahahaha', foo));
-(true && !(false) && Ember.assert('without predicate'));
-(true && !(true) && Ember.deprecate('This thing is donzo', true, {
+(true && warn('This is a warning'));
+(true && !(foo) && assert('Hahahaha', foo));
+(true && !(false) && assert('without predicate'));
+(true && !(true) && deprecate('This thing is donzo', true, {
   id: 'donzo',
   until: '4.0.0',
   url: 'http://example.com'

--- a/tests/create-tests.js
+++ b/tests/create-tests.js
@@ -171,61 +171,91 @@ function createTests(options) {
     h.generateTest('global-external-helpers');
   });
 
-  describe('ember-cli-babel default configuration (legacy config API)', function() {
-    beforeEach(function() {
-      console.warn = () => {}; // eslint-disable-line
-    });
+  describe('ember-cli-babel configuration', function() {
+    describe('Ember < 3.27', function() {
+      describe('legacy config API', function() {
+        beforeEach(function() {
+          console.warn = () => {}; // eslint-disable-line
+        });
 
-    let h = transformTestHelper({
-      presets,
-      plugins: [
-        [
-          DebugToolsPlugin,
-          {
-            externalizeHelpers: {
-              global: 'Ember',
-            },
-            debugTools: {
-              isDebug: true,
-              source: '@ember/debug',
-              assertPredicateIndex: 1,
-            },
-            envFlags: {
-              source: '@glimmer/env',
-              flags: {
-                DEBUG: true,
+        let h = transformTestHelper({
+          presets,
+          plugins: [
+            [
+              DebugToolsPlugin,
+              {
+                externalizeHelpers: {
+                  global: 'Ember',
+                },
+                debugTools: {
+                  isDebug: true,
+                  source: '@ember/debug',
+                  assertPredicateIndex: 1,
+                },
+                envFlags: {
+                  source: '@glimmer/env',
+                  flags: {
+                    DEBUG: true,
+                  },
+                },
               },
-            },
-          },
-        ],
-      ],
+            ],
+          ],
+        });
+
+        h.generateTest('ember-cli-babel-config-pre-3-27');
+      });
+
+      describe('default configuration', function() {
+        let h = transformTestHelper({
+          presets,
+          plugins: [
+            [
+              DebugToolsPlugin,
+              {
+                externalizeHelpers: {
+                  global: 'Ember',
+                },
+                debugTools: {
+                  isDebug: true,
+                  source: '@ember/debug',
+                  assertPredicateIndex: 1,
+                },
+                flags: [{ source: '@glimmer/env', flags: { DEBUG: true } }],
+              },
+            ],
+          ],
+        });
+
+        h.generateTest('ember-cli-babel-config-pre-3-27');
+      });
     });
 
-    h.generateTest('ember-cli-babel-config');
-  });
+    describe('Ember >= 3.27', function() {
+      describe('default configuration', function() {
+        let h = transformTestHelper({
+          presets,
+          plugins: [
+            [
+              DebugToolsPlugin,
+              {
+                externalizeHelpers: {
+                  module: '@ember/debug',
+                },
+                debugTools: {
+                  isDebug: true,
+                  source: '@ember/debug',
+                  assertPredicateIndex: 1,
+                },
+                flags: [{ source: '@glimmer/env', flags: { DEBUG: true } }],
+              },
+            ],
+          ],
+        });
 
-  describe('ember-cli-babel default configuration', function() {
-    let h = transformTestHelper({
-      presets,
-      plugins: [
-        [
-          DebugToolsPlugin,
-          {
-            externalizeHelpers: {
-              global: 'Ember',
-            },
-            debugTools: {
-              isDebug: true,
-              source: '@ember/debug',
-              assertPredicateIndex: 1,
-            },
-            flags: [{ source: '@glimmer/env', flags: { DEBUG: true } }],
-          },
-        ],
-      ],
+        h.generateTest('ember-cli-babel-config');
+      });
     });
-
-    h.generateTest('ember-cli-babel-config');
   });
 
   describe('Retain Module External Test Helpers', function() {


### PR DESCRIPTION
No changes were needed (we already supported a modules based API), but this documents the chagnes needed in ember-cli-babel@7.26 to avoid knock on deprecations.

Closes https://github.com/ember-cli/babel-plugin-debug-macros/issues/87
