### PR TITLE
Add a mode that converts to @embroider/macros

### DIFF
--- a/fixtures/embroider-macros/assert/expectation7.js
+++ b/fixtures/embroider-macros/assert/expectation7.js
@@ -1,0 +1,5 @@
+import { assert } from '@ember/debug';
+import { isDevelopingApp } from '@embroider/macros';
+
+isDevelopingApp() && !(() => true )() && assert('This is an assertion', (() => true )());
+isDevelopingApp() && !false && assert('This is an assertion 2', false);

--- a/fixtures/embroider-macros/assert/sample.js
+++ b/fixtures/embroider-macros/assert/sample.js
@@ -1,0 +1,4 @@
+import { assert } from '@ember/debug';
+
+assert('This is an assertion', (() => true )());
+assert('This is an assertion 2', false);

--- a/fixtures/embroider-macros/deprecate/expectation7.js
+++ b/fixtures/embroider-macros/deprecate/expectation7.js
@@ -1,0 +1,10 @@
+import { deprecate } from '@ember/debug';
+import { isDevelopingApp } from '@embroider/macros';
+
+isDevelopingApp() &&
+  !false &&
+  deprecate('This is deprecated', false, {
+    until: '3.0.0',
+    id: 'a-thing',
+    url: 'http://example.com',
+  });

--- a/fixtures/embroider-macros/deprecate/sample.js
+++ b/fixtures/embroider-macros/deprecate/sample.js
@@ -1,0 +1,7 @@
+import { deprecate } from '@ember/debug';
+
+deprecate('This is deprecated', false, {
+  until: '3.0.0',
+  id: 'a-thing',
+  url: 'http://example.com'
+})

--- a/fixtures/embroider-macros/glimmer-env/expectation7.js
+++ b/fixtures/embroider-macros/glimmer-env/expectation7.js
@@ -1,0 +1,5 @@
+import { isDevelopingApp } from '@embroider/macros';
+
+if (isDevelopingApp()) {
+  console.log('stuff');
+}

--- a/fixtures/embroider-macros/glimmer-env/sample.js
+++ b/fixtures/embroider-macros/glimmer-env/sample.js
@@ -1,0 +1,5 @@
+import { DEBUG } from '@glimmer/env';
+
+if (DEBUG) {
+  console.log('stuff');
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     ]
   },
   "dependencies": {
+    "babel-import-util": "^2.0.2",
     "semver": "^7.6.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  babel-import-util:
+    specifier: ^2.0.2
+    version: 2.0.2
   semver:
     specifier: ^7.6.0
     version: 7.6.0
@@ -2232,6 +2235,11 @@ packages:
     dependencies:
       possible-typed-array-names: 1.0.0
     dev: true
+
+  /babel-import-util@2.0.2:
+    resolution: {integrity: sha512-pR4vWlVujmYENFbceYcLPYCD+ulYGfmNmbTVd6Xp49d0uk+K3sWy6+O+5RLEa0OonXw9rf3hc9xFmglFnS0MWg==}
+    engines: {node: '>= 12.*'}
+    dev: false
 
   /babel-jest@29.7.0(@babel/core@7.24.4):
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}

--- a/src/utils/normalize-options.ts
+++ b/src/utils/normalize-options.ts
@@ -1,7 +1,7 @@
 import { gt } from 'semver';
 
 function parseDebugTools(options: UserOptions): {
-  isDebug: boolean;
+  isDebug: boolean | '@embroider/macros';
   debugToolsImport: string;
   assertPredicateIndex: number | undefined;
 } {
@@ -26,8 +26,8 @@ function evaluateFlagValue(
   options: UserOptions,
   name: string | undefined,
   flagName: string,
-  flagValue: string | boolean | null
-): boolean | null {
+  flagValue: string | boolean | null | "@embroider/macros"
+): boolean | null | "@embroider/macros" {
   let svelte = options.svelte;
 
   if (typeof flagValue === 'string' && name) {
@@ -38,15 +38,19 @@ function evaluateFlagValue(
     }
   } else if (typeof flagValue === 'boolean' || flagValue === null) {
     return flagValue;
+  } else if (flagValue === '@embroider/macros') {
+    return flagValue;
   } else {
     throw new Error(`Invalid value specified (${flagValue}) for ${flagName} by ${name}`);
   }
 }
 
-function parseFlags(options: UserOptions): Record<string, Record<string, boolean | null>> {
+function parseFlags(
+  options: UserOptions
+): Record<string, Record<string, boolean | null | '@embroider/macros'>> {
   let flagsProvided = options.flags || [];
 
-  let combinedFlags: Record<string, Record<string, boolean | null>> = {};
+  let combinedFlags: Record<string, Record<string, boolean | null | '@embroider/macros'>> = {};
   flagsProvided.forEach((flagsDefinition) => {
     let source = flagsDefinition.source;
     let flagsForSource = (combinedFlags[source] = combinedFlags[source] || {});
@@ -71,9 +75,9 @@ export interface NormalizedOptions {
     module?: boolean;
     global?: string;
   };
-  flags: Record<string, Record<string, boolean | null>>;
+  flags: Record<string, Record<string, boolean | null | '@embroider/macros'>>;
   debugTools: {
-    isDebug: boolean;
+    isDebug: boolean | '@embroider/macros';
     debugToolsImport: string;
     assertPredicateIndex: number | undefined;
   };
@@ -85,9 +89,13 @@ export interface UserOptions {
     global?: string;
   };
   svelte?: Record<string, string>;
-  flags?: { source: string; name?: string; flags: Record<string, boolean | string | null> }[];
+  flags?: {
+    source: string;
+    name?: string;
+    flags: Record<string, boolean | string | null | '@embroider/macros'>;
+  }[];
   debugTools?: {
-    isDebug: boolean;
+    isDebug: boolean | '@embroider/macros';
     source: string;
     assertPredicateIndex?: number;
   };


### PR DESCRIPTION
This is intended as a compatibility path for packages (like ember-source) that make heavy use of babel-plugin-debug-macros and want to become valid V2 addons.

A v2 addon can't bring its own custom build pipeline along into apps. If they want to make compile-time decisions, they need to do it through the standardized `@embroider/macros`.

This implementation does the smallest, simplest thing, which is replacing the hard-coded boolean we used to emit with a call to `isDevelopingApp()` from '@embroider/macros`. It relies on the same kind of dead-code elimination that this babel plugin has always relied on.