### PR TITLE
docs(README.md)/ Fix a typo in the name of the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ options.
 ```js
 {
   plugins: [
-    ['babel-debug-macros', {
+    ['babel-plugin-debug-macros', {
       // @optional
       debugTools: {
         isDebug: true,


### PR DESCRIPTION
Probably an artifact from the [old package name](https://github.com/ember-cli/babel-plugin-debug-macros/blob/main/package.json#L11)?