### PR TITLE
Expand debug statements in place to permit subsequent Babel plugin translation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -100,7 +100,7 @@ export default function macros(babel: typeof Babel): Babel.PluginObj<State> {
         },
 
         exit() {
-          this.macroBuilder.expand();
+          this.macroBuilder.cleanImports();
         },
       },
 

--- a/src/utils/builder.ts
+++ b/src/utils/builder.ts
@@ -147,10 +147,10 @@ export default class Builder {
       prefixedIdentifiers.push(negatedPredicate);
     }
 
-    this.expandMacro(
-      path,
-      this._buildLogicalExpressions(prefixedIdentifiers, callExpression),
-    );
+    // Expand the macro!
+    let replacementPath = this._buildLogicalExpressions(prefixedIdentifiers, callExpression, this._debugExpression(path));
+    path.replaceWith(replacementPath);
+    path.scope.crawl();
   }
 
   /**
@@ -208,15 +208,6 @@ export default class Builder {
     });
   }
 
-  /**
-   * Performs the actually expansion of macro
-   */
-  expandMacro(exp: CallStatementPath, logicalExp: (debugIdentifier: t.Expression) => t.Expression) {
-    const flag = this._debugExpression(exp);
-    exp.replaceWith(this.t.parenthesizedExpression(logicalExp(flag)));
-    exp.scope.crawl();
-  }
-
   _debugExpression(target: NodePath) {
     if (typeof this.isDebug === 'boolean') {
       return this.t.booleanLiteral(this.isDebug);
@@ -244,26 +235,25 @@ export default class Builder {
 
   _buildLogicalExpressions(
     identifiers: t.Expression[],
-    callExpression: t.Expression
-  ): (debugIdentifier: t.Expression) => t.Expression {
+    callExpression: t.Expression,
+    debugIdentifier: t.Expression
+  ): t.Expression {
     let t = this.t;
 
-    return (debugIdentifier: t.Expression) => {
-      identifiers.unshift(debugIdentifier);
-      identifiers.push(callExpression);
-      let logicalExpressions;
+    identifiers.unshift(debugIdentifier);
+    identifiers.push(callExpression);
+    let logicalExpressions;
 
-      for (let i = 0; i < identifiers.length; i++) {
-        let left = identifiers[i];
-        let right = identifiers[i + 1];
-        if (!logicalExpressions) {
-          logicalExpressions = t.logicalExpression('&&', left, right);
-        } else if (right) {
-          logicalExpressions = t.logicalExpression('&&', logicalExpressions, right);
-        }
+    for (let i = 0; i < identifiers.length; i++) {
+      let left = identifiers[i];
+      let right = identifiers[i + 1];
+      if (!logicalExpressions) {
+        logicalExpressions = t.logicalExpression('&&', left, right);
+      } else if (right) {
+        logicalExpressions = t.logicalExpression('&&', logicalExpressions, right);
       }
+    }
 
-      return logicalExpressions!;
-    };
+    return t.parenthesizedExpression(logicalExpressions!);
   }
 }

--- a/src/utils/builder.ts
+++ b/src/utils/builder.ts
@@ -30,8 +30,6 @@ export default class Builder {
   private isDebug: boolean | '@embroider/macros';
   private util: ImportUtil;
 
-  private expressions: [CallStatementPath, (debugIdentifier: t.Expression) => t.Expression][] = [];
-
   constructor(
     readonly t: typeof Babel.types,
     util: ImportUtil,
@@ -149,10 +147,10 @@ export default class Builder {
       prefixedIdentifiers.push(negatedPredicate);
     }
 
-    this.expressions.push([
+    this.expandMacro(
       path,
       this._buildLogicalExpressions(prefixedIdentifiers, callExpression),
-    ]);
+    );
   }
 
   /**
@@ -211,18 +209,12 @@ export default class Builder {
   }
 
   /**
-   * Performs the actually expansion of macros
+   * Performs the actually expansion of macro
    */
-  expandMacros() {
-    let t = this.t;
-    for (let i = 0; i < this.expressions.length; i++) {
-      let expression = this.expressions[i];
-      let exp = expression[0];
-      let flag = this._debugExpression(exp);
-      let logicalExp = expression[1];
-      exp.replaceWith(t.parenthesizedExpression(logicalExp(flag)));
-      exp.scope.crawl();
-    }
+  expandMacro(exp: CallStatementPath, logicalExp: (debugIdentifier: t.Expression) => t.Expression) {
+    const flag = this._debugExpression(exp);
+    exp.replaceWith(this.t.parenthesizedExpression(logicalExp(flag)));
+    exp.scope.crawl();
   }
 
   _debugExpression(target: NodePath) {

--- a/src/utils/macros.ts
+++ b/src/utils/macros.ts
@@ -27,14 +27,6 @@ export default class Macros {
   }
 
   /**
-   * Injects the either the env-flags module with the debug binding or
-   * adds the debug binding if missing from the env-flags module.
-   */
-  expand() {
-    this._cleanImports();
-  }
-
-  /**
    * Collects the import bindings for the debug tools.
    */
   collectDebugToolsSpecifiers(
@@ -53,7 +45,7 @@ export default class Macros {
   }
 
   /**
-   * Builds the expressions that the CallExpression will expand into.
+   * Expands the given expression, if it is simple CallExpression statement for the debug tools.
    */
   build(path: NodePath<t.ExpressionStatement>) {
     if (!isCallStatementPath(path)) {
@@ -68,7 +60,10 @@ export default class Macros {
     }
   }
 
-  _cleanImports() {
+  /**
+   * Removes obsolete import bindings for the debug tools.
+   */
+  cleanImports() {
     if (!this.debugHelpers?.module) {
       if (this.localDebugBindings.length > 0) {
         let importPath = this.localDebugBindings[0].findParent((p) =>

--- a/src/utils/macros.ts
+++ b/src/utils/macros.ts
@@ -31,8 +31,6 @@ export default class Macros {
    * adds the debug binding if missing from the env-flags module.
    */
   expand() {
-    this.builder.expandMacros();
-
     this._cleanImports();
   }
 


### PR DESCRIPTION
## Problem

Whenever this plugin encounters a debug function call statement, its builder performs a partial translation that gets fully resolved and substituted only once `expandMacros` is called at the exit of the file.

While this behavior works fine for standalone translation, the deferred substitution fails to permit other registered Babel plugins the opportunity to translate the replacement expression, due to the nature of Babel's one-shot AST traversal.

In particular, this poses a problem when using the `'@embroider/macros'` condition, since the resulting `isDevelopingApp()` call expression is not seen by the later Babel plugin from @embroider/macros.

## Solution

Rather than collecting all expressions for later expansion, this change expands the debug statements in-place, and in doing so, Babel passes the replacement expression to all registered plugins.  (This includes the current plugin, but the replacement expression statement is always a logical expression rather than a direct call statement, so it is not subject to re-processing by this plugin.)

### Concern: Chesterton's Fence 

It is unclear to me why the plugin was originally written in the manner where it collects expressions for later substitution, and whether modifying this behavior will lead to other problems.  It appears that this was the behavior from the initial commit 99c4e6be86122be12ec0ac2fa5b6288ebdb3ec69, and the purpose in that code seems to have been that logic for calculating the debug flag was implemented in the Program.exit hook, so the final expression was only known at that point.  It's unclear to me why exactly this approach was taken and has been preserved through a variety of refactors, but I suspect it is related in some way to the need to determine whether/how to adjust module imports, which is no longer a necessity.  My hope therefore is that the effect of this change will not have adverse effects on existing usages.